### PR TITLE
Fixed instances of deserialize to serialize

### DIFF
--- a/src/file_tools.rs
+++ b/src/file_tools.rs
@@ -1,15 +1,15 @@
 use std::path::PathBuf;
 
-pub trait Deserialize {
-    fn deserialize(&self) -> String;
+pub trait Serialize {
+    fn serialize(&self) -> String;
 }
 
 pub struct OsuAudioFilename {
     pub name: PathBuf,
 }
 
-impl Deserialize for OsuAudioFilename {
-    fn deserialize(&self) -> String {
+impl Serialize for OsuAudioFilename {
+    fn serialize(&self) -> String {
         return format!("AudioFilename: {}", self.name.display());
     }
 }
@@ -18,8 +18,8 @@ pub struct SM5AudioFilename {
     name: PathBuf
 }
 
-impl Deserialize for SM5AudioFilename {
-    fn deserialize(&self) -> String {
+impl Serialize for SM5AudioFilename {
+    fn serialize(&self) -> String {
         return format!("#MUSIC:{}", self.name.display());
     }
 }
@@ -36,8 +36,8 @@ pub struct OsuTitle {
     pub name: PathBuf,
 }
 
-impl Deserialize for OsuTitle {
-    fn deserialize(&self) -> String {
+impl Serialize for OsuTitle {
+    fn serialize(&self) -> String {
         return format!("TitleUnicode:{}", self.name.display());
     }
 }
@@ -46,8 +46,8 @@ pub struct SM5Title {
     name: PathBuf
 }
 
-impl Deserialize for SM5Title {
-    fn deserialize(&self) -> String {
+impl Serialize for SM5Title {
+    fn serialize(&self) -> String {
         return format!("#TITLE:{}", self.name.display());
     }
 }
@@ -64,8 +64,8 @@ pub struct OsuPreviewTime {
     pub time: u32,
 }
 
-impl Deserialize for OsuPreviewTime {
-    fn deserialize(&self) -> String {
+impl Serialize for OsuPreviewTime {
+    fn serialize(&self) -> String {
         return format!("PreviewTime: {}", self.time.to_string());
     }
 }
@@ -74,8 +74,8 @@ pub struct SM5PreviewTime {
     time: f64
 }
 
-impl Deserialize for SM5PreviewTime {
-    fn deserialize(&self) -> String {
+impl Serialize for SM5PreviewTime {
+    fn serialize(&self) -> String {
         return format!("#SAMPLESTART:{};\n", self.time.to_string());
     }
 }
@@ -92,8 +92,8 @@ pub struct OsuArtist {
     pub name: PathBuf,
 }
 
-impl Deserialize for OsuArtist {
-    fn deserialize(&self) -> String {
+impl Serialize for OsuArtist {
+    fn serialize(&self) -> String {
         return format!("ArtistUnicode:{}", self.name.display());
     }
 }
@@ -102,8 +102,8 @@ pub struct SM5Artist {
     name: PathBuf
 }
 
-impl Deserialize for SM5Artist {
-    fn deserialize(&self) -> String {
+impl Serialize for SM5Artist {
+    fn serialize(&self) -> String {
         return format!("#ARTIST:{};\n", self.name.display());
     }
 }
@@ -120,8 +120,8 @@ pub struct OsuVersion {
     pub version: PathBuf,
 }
 
-impl Deserialize for OsuVersion {
-    fn deserialize(&self) -> String {
+impl Serialize for OsuVersion {
+    fn serialize(&self) -> String {
         return format!("Version:{}", self.version.display());
     }
 }
@@ -130,8 +130,8 @@ pub struct SM5Version {
     version: PathBuf
 }
 
-impl Deserialize for SM5Version {
-    fn deserialize(&self) -> String {
+impl Serialize for SM5Version {
+    fn serialize(&self) -> String {
         return format!("#SUBTITLE:{};\n", self.version.display());
     }
 }

--- a/src/osu_parser.rs
+++ b/src/osu_parser.rs
@@ -1,6 +1,6 @@
 // osu!std file parser
 use std::{fs::File, io::{self, stdin, stdout, Read, Write}, path::{Path, PathBuf}, vec}; //, collections::HashMap};
-use crate::file_tools::{Deserialize, OsuArtist, OsuAudioFilename, OsuPreviewTime, OsuTitle, OsuVersion, SM5Artist, SM5AudioFilename, SM5PreviewTime, SM5Title, SM5Version};
+use crate::file_tools::{Serialize, OsuArtist, OsuAudioFilename, OsuPreviewTime, OsuTitle, OsuVersion, SM5Artist, SM5AudioFilename, SM5PreviewTime, SM5Title, SM5Version};
 use crate::osu_util::Delimiter;
 
 #[derive(Clone)]
@@ -256,13 +256,13 @@ impl OsuParser {
                     if key == "AudioFilename" {
                         let osu_field = OsuAudioFilename { name: PathBuf::from(value) };
                         let sm5_audio_filename: SM5AudioFilename = From::from(osu_field);
-                        file.write(sm5_audio_filename.deserialize().as_bytes()).expect("Unable to write data");
+                        file.write(sm5_audio_filename.serialize().as_bytes()).expect("Unable to write data");
                     }
                     else if key == "PreviewTime" {
                         let time = value.parse::<u32>().unwrap();
                         let osu_field = OsuPreviewTime { time };
                         let sm5_preview_time: SM5PreviewTime = From::from(osu_field);
-                        file.write(sm5_preview_time.deserialize().as_bytes()).expect("Unable to write data");
+                        file.write(sm5_preview_time.serialize().as_bytes()).expect("Unable to write data");
                         file.write("#SAMPLELENGTH:20.000;\n".as_bytes()).expect("Unable to write data");
                     }
                 }
@@ -289,17 +289,17 @@ impl OsuParser {
                     if key == "TitleUnicode" {
                         let osu_field = OsuTitle { name: PathBuf::from(value) };
                         let sm5_title: SM5Title = From::from(osu_field);
-                        file.write(sm5_title.deserialize().as_bytes()).expect("Unable to write data");
+                        file.write(sm5_title.serialize().as_bytes()).expect("Unable to write data");
                     }
                     else if key == "ArtistUnicode" {
                         let osu_field = OsuArtist { name: PathBuf::from(value) };
                         let sm5_artist: SM5Artist = From::from(osu_field);
-                        file.write(sm5_artist.deserialize().as_bytes()).expect("Unable to write data");
+                        file.write(sm5_artist.serialize().as_bytes()).expect("Unable to write data");
                     }
                     else if key == "Version" {
                         let osu_field = OsuVersion { version: PathBuf::from(value) };
                         let sm5_version: SM5Version = From::from(osu_field);
-                        file.write(sm5_version.deserialize().as_bytes()).expect("Unable to write data");
+                        file.write(sm5_version.serialize().as_bytes()).expect("Unable to write data");
                     }
                 }
             }


### PR DESCRIPTION
`file_tools.rs` contained incorrectly labeled traits and functions. Function and trait names were updated to be named `Serialize` to accurately reflect code behavior.